### PR TITLE
chore(ci): altera quando faz push wip em vez de main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [main]
+    branches: [wip]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
- Altera para quando feito o push na branch wip, ele faz os testes para verificar se está tudo correto, logo após isso, se caso passar, indica que podemos fazer um pull request para a Main sem problemas